### PR TITLE
Added axis representation handling and fixed issues in Linear and SymmetricTop coding

### DIFF
--- a/pyspectools/pypickett/classes.py
+++ b/pyspectools/pypickett/classes.py
@@ -691,7 +691,7 @@ def infer_molecule(parameters: Dict[str, Union[str, float]]) -> Type[AbstractMol
     """
     if all([key in parameters.keys() for key in ["A", "B", "C"]]):
         return AsymmetricTop
-    elif all([key in parameters.keys() for key in ["A", "B"]]):
+    elif all([key in parameters.keys() for key in ["A-B", "B"]]) or all([key in parameters.keys() for key in ["B-C", "B"]]):
         return SymmetricTop
     else:
         return LinearMolecule
@@ -756,7 +756,7 @@ def load_molecule_yaml(
     # infer the reduction from the keys specified
     var_kwargs = {
         "mu": mu,
-        "s_reduced": True if "D_J" in data else False,
+        "s_reduced": False if "Delta_J" in data else True,
     }
     # look for the axis representation, if it does not appear as a parameter or
     # is not a supported representation, then choose one based on the value of 

--- a/pyspectools/pypickett/utils.py
+++ b/pyspectools/pypickett/utils.py
@@ -13,7 +13,7 @@ from pyspectools import routines
 
 par_template = """PySpecTools SPCAT input
  100  255    1    0    0.0000E+000    1.0000E+003    1.0000E+000 1.0000000000
-{reduction}   {quanta}    {top}    0   {k_max}    0    {weight_axis}    {even_weight}    {odd_weight}     0   1   0
+{reduction}   {quanta}    {representation}    0   {k_max}    0    {weight_axis}    {even_weight}    {odd_weight}     0   1   0
 {parameters}
 """
 


### PR DESCRIPTION
The first commit addresses Fixes 1 and 3 from Issue #36 on handling axis representations for SPCAT files. Five cases are handled:
1. LinearMolecule and prolate SymmetricTop assigned representation "Ir" (SPCAT coding requirement)
2. oblate SymmetricTop assigned representation "IIIl" (SPCAT coding requirement)
3. AsymmetricTop with "rep" = "Ir" or "IIIl" specified in YAML file assigned to that representation
4. AsymmetricTop with a different "rep" value is assigned to "Ir" or "IIIl" based on the value of Ray's asymmetry parameter, implemented with `kappa` from `pyspectools.units`. If `kappa>0`, "IIIl" is assigned, and "Ir" otherwise.
5. AsymmetricTop with no "rep" specified. "Ir" or "IIIl" assigned by same `kappa` metric.

The second commit fixes some minor issues in the coding for Linear and SymmetricTop molecules. The flag `s_reduced` now defaults True, so that `s` is called in .var file for these molecules. `infer_molecule` now assigns a SymmetricTop if ("A-B" and "B") or ("B-C" and "B") are present. This aligns with the current coding for SymmetricTop, which uses "A-B". "B-C" was not added to coding because it is currently unclear to me how this is distinguished from "H_K" in Pickett code (see [crib sheet](http://info.ifpan.edu.pl/~kisiel/asym/pickett/crib.htm#symh)). Other codings of symmetric tops are possible in SPCAT.